### PR TITLE
Make requirements more precise

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,10 @@
-numpy
-tensorflow
-sklearn
-gensim<=3.1
-h5py
+numpy>=1.13
+scipy==1.2.1
+tensorflow~=1.4
+keras~=2.0
+gensim==3.1
+pymorphy2==0.8
+nltk
+nltk_data
+scikit-learn
 tqdm
-keras>=2.0


### PR DESCRIPTION
@madrugado , hello!

I have had to change requirements to use this project.

1) On `scipy>1.2.1`:
```
Traceback (most recent call last):
  File "train.py", line 101, in <module>
    model = create_model(args, overall_maxlen, vocab)
  File "<...>/code/model.py", line 25, in create_model
    from w2vEmbReader import W2VEmbReader as EmbReader
  File "<...>/code/w2vEmbReader.py", line 5, in <module>
    import gensim
  File "/opt/miniconda3/envs/gosfeedback/lib/python3.6/site-packages/gensim/__init__.py", line 6, in <module>
    from gensim import parsing, matutils, interfaces, corpora, models, similarities, summarization, utils  # noqa:F401
  File "/opt/miniconda3/envs/gosfeedback/lib/python3.6/site-packages/gensim/models/__init__.py", line 8, in <module>
    from .hdpmodel import HdpModel  # noqa:F401
  File "/opt/miniconda3/envs/gosfeedback/lib/python3.6/site-packages/gensim/models/hdpmodel.py", line 46, in <module>
    from gensim.models import basemodel, ldamodel
  File "/opt/miniconda3/envs/gosfeedback/lib/python3.6/site-packages/gensim/models/ldamodel.py", line 51, in <module>
    from scipy.misc import logsumexp
ImportError: cannot import name 'logsumexp'
```

2) Why `gensim` was `<=3.1`?
Update: oh, now I see #1. But according to [docs](https://radimrehurek.com/gensim/models/word2vec.html#gensim.models.word2vec.Word2Vec), `gensim.models.word2vec.Word2Vec#vocabulary` still presents...

3) And I've not found using of `h5py`.

Hope on merging and/or discussion. Thanks!