### PR TITLE
Model: fix shape[i].value

### DIFF
--- a/code/model.py
+++ b/code/model.py
@@ -16,7 +16,7 @@ def create_model(args, maxlen, vocab):
     def ortho_reg(weight_matrix):
         ### orthogonal regularization for aspect embedding matrix ###
         w_n = K.l2_normalize(weight_matrix, axis=-1)
-        reg = K.sum(K.square(K.dot(w_n, K.transpose(w_n)) - K.eye(w_n.shape[0].value)))
+        reg = K.sum(K.square(K.dot(w_n, K.transpose(w_n)) - K.eye(w_n.shape[0])))
         return args.ortho_reg * reg
 
     vocab_size = len(vocab)

--- a/code/my_layers.py
+++ b/code/my_layers.py
@@ -202,7 +202,7 @@ class MaxMargin(Layer):
         z_n = K.l2_normalize(z_n, axis=-1)
         r_s = K.l2_normalize(r_s, axis=-1)
 
-        steps = z_n.shape[1].value
+        steps = z_n.shape[1]
 
         pos = K.sum(z_s * r_s, axis=-1, keepdims=True)
         pos = K.repeat_elements(pos, steps, axis=1)


### PR DESCRIPTION
@madrugado , hello!

I don't know if it's correct. But code didn't work without that for me:
```
Traceback (most recent call last):
  File "train.py", line 101, in <module>
    model = create_model(args, overall_maxlen, vocab)
  File "<...>/code/model.py", line 57, in create_model
    W_regularizer=ortho_reg)(p_t)
  File "/opt/miniconda3/envs/gosfeedback/lib/python3.6/site-packages/keras/backend/tensorflow_backend.py", line 75, in symbolic_fn_wrapper
    return func(*args, **kwargs)
  File "/opt/miniconda3/envs/gosfeedback/lib/python3.6/site-packages/keras/engine/base_layer.py", line 463, in __call__
    self.build(unpack_singleton(input_shapes))
  File "<...>/code/my_layers.py", line 139, in build
    constraint=self.W_constraint)
  File "/opt/miniconda3/envs/gosfeedback/lib/python3.6/site-packages/keras/engine/base_layer.py", line 285, in add_weight
    self.add_loss(regularizer(weight))
  File "<...>/code/model.py", line 19, in ortho_reg
    reg = K.sum(K.square(K.dot(w_n, K.transpose(w_n)) - K.eye(w_n.shape[0].value)))
AttributeError: 'int' object has no attribute 'value'
```

Hope on discussion. Thanks!